### PR TITLE
Allow mobile users to zoom in

### DIFF
--- a/html/partial/head.tmpl
+++ b/html/partial/head.tmpl
@@ -1,7 +1,7 @@
 {{define "head"}}
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0,user-scalable=0"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>{{if .title}}{{.title}} | {{end}}{{SiteTitle}}</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>{{SiteFavicon}}</text></svg>">
     {{if StylesAppend}}<link rel="stylesheet" href="{{"/assets/css/style.css" | AssetStamp}}">{{end}}


### PR DESCRIPTION
If the user wants to zoom in, we shouldn't stop them. Some mobile browsers have started to ignore instructions to disable pinch zoom; users on browsers that still respect `user-scalable` get a worse experience.

See also HermanMartinus/bearblog#130.

This change has already been applied to our instance at https://blog.kagi.com/; h/t https://news.ycombinator.com/item?id=43725048 for bringing the issue to our attention.